### PR TITLE
Update union type checking

### DIFF
--- a/lib/ex_type/argument_expander.ex
+++ b/lib/ex_type/argument_expander.ex
@@ -1,0 +1,47 @@
+defmodule ExType.ArgumentExpander do
+  @moduledoc false
+
+  alias ExType.{Assert, Type}
+
+  @type type :: Type.t()
+
+  @spec expand_union_types([type]) :: [[type]]
+
+  # for example, if input is [t1 | t2, t3 | t4]
+  # it would be expanded to [ [t1, t3], [t1, t4], [t2, t3], [t2, t4] ]
+
+  def expand_union_types([]) do
+    []
+  end
+
+  def expand_union_types([%Type.Union{types: inner_types} = union_type]) do
+    Assert.no_nested_union_types!(union_type)
+
+    Enum.map(inner_types, fn type -> [type] end)
+  end
+
+  def expand_union_types([non_union_type]) do
+    [[non_union_type]]
+  end
+
+  def expand_union_types([%Type.Union{types: inner_types} = union_type | rest_types])
+      when length(rest_types) > 0 do
+    Assert.no_nested_union_types!(union_type)
+
+    rest_types
+    |> expand_union_types()
+    |> Enum.flat_map(fn expanded_rest_types ->
+      Enum.map(inner_types, fn inner_type ->
+        [inner_type | expanded_rest_types]
+      end)
+    end)
+  end
+
+  def expand_union_types([non_union_type | rest_types]) when length(rest_types) > 0 do
+    rest_types
+    |> expand_union_types()
+    |> Enum.map(fn result_type ->
+      [non_union_type | result_type]
+    end)
+  end
+end

--- a/lib/ex_type/assert.ex
+++ b/lib/ex_type/assert.ex
@@ -1,0 +1,41 @@
+defmodule ExType.Assert do
+  @moduledoc false
+
+  alias ExType.Type
+
+  @spec no_nested_union_types!(Type.Union.t()) :: :ok
+
+  def no_nested_union_types!(%Type.Union{types: inner_types} = union_type) do
+    Enum.each(inner_types, fn
+      %Type.Union{} ->
+        raise "found nested union type: #{inspect(union_type)}"
+
+      _ ->
+        :ok
+    end)
+  end
+
+  defp type_struct?(type) do
+    with %{__struct__: struct} <- type,
+         ["ExType", "Type", _] <- Module.split(struct) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  @spec is_type_struct!(map()) :: :ok
+
+  def is_type_struct!(type) do
+    case type_struct?(type) do
+      true -> :ok
+      false -> raise "#{inspect(type)} is not ExType.Type.Xxx struct"
+    end
+  end
+
+  @spec is_list_of_type_structs!([map()]) :: :ok
+
+  def is_list_of_type_structs!(types) when is_list(types) do
+    Enum.each(types, &is_type_struct!(&1))
+  end
+end

--- a/lib/ex_type/type.ex
+++ b/lib/ex_type/type.ex
@@ -1,6 +1,8 @@
 defmodule ExType.Type do
   @moduledoc false
 
+  alias ExType.Assert
+
   @type t ::
           ExType.Type.Any.t()
           | ExType.Type.None.t()
@@ -36,6 +38,8 @@ defmodule ExType.Type do
     defstruct []
   end
 
+  def any, do: %Any{}
+
   defmodule None do
     @moduledoc false
 
@@ -43,6 +47,8 @@ defmodule ExType.Type do
 
     defstruct []
   end
+
+  def none, do: %None{}
 
   defmodule Union do
     @moduledoc false
@@ -54,6 +60,14 @@ defmodule ExType.Type do
     defstruct [:types]
   end
 
+  def union(types) when is_list(types) do
+    Assert.is_list_of_type_structs!(types)
+
+    %Union{types: types}
+  end
+
+  # assert_type_struct
+
   defmodule Intersection do
     @moduledoc false
 
@@ -62,6 +76,11 @@ defmodule ExType.Type do
           }
 
     defstruct [:types]
+  end
+
+  def intersection(types) when is_list(types) do
+    Assert.is_list_of_type_structs!(types)
+    %Intersection{types: types}
   end
 
   defmodule SpecVariable do
@@ -95,6 +114,12 @@ defmodule ExType.Type do
     defstruct [:module, :generic]
   end
 
+  def generic_protocol(module, generic) do
+    Assert.is_type_struct!(generic)
+
+    %GenericProtocol{module: module, generic: generic}
+  end
+
   defmodule Float do
     @moduledoc false
 
@@ -103,6 +128,8 @@ defmodule ExType.Type do
     defstruct []
   end
 
+  def float, do: %Float{}
+
   defmodule Integer do
     @moduledoc false
 
@@ -110,6 +137,8 @@ defmodule ExType.Type do
 
     defstruct []
   end
+
+  def integer, do: %Integer{}
 
   defmodule Atom do
     @moduledoc false
@@ -122,6 +151,8 @@ defmodule ExType.Type do
     defstruct [:literal, :value]
   end
 
+  def atom, do: %Atom{}
+
   defmodule Reference do
     @moduledoc false
 
@@ -130,6 +161,8 @@ defmodule ExType.Type do
     defstruct []
   end
 
+  def reference, do: %Reference{}
+
   defmodule AnyFunction do
     @moduledoc false
 
@@ -137,6 +170,8 @@ defmodule ExType.Type do
 
     defstruct []
   end
+
+  def any_function, do: %AnyFunction{}
 
   defmodule RawFunction do
     @moduledoc false
@@ -170,6 +205,12 @@ defmodule ExType.Type do
     defstruct [:type]
   end
 
+  def list(type) do
+    Assert.is_type_struct!(type)
+
+    %List{type: type}
+  end
+
   # StructLikeMap
   # Map.StructLike => it's map, not struct, but it has all atom as key,
   #                   so it's struct like map
@@ -183,6 +224,13 @@ defmodule ExType.Type do
           }
 
     defstruct [:key, :value]
+  end
+
+  def map(key_type, value_type) do
+    Assert.is_type_struct!(key_type)
+    Assert.is_type_struct!(value_type)
+
+    %Map{key: key_type, value: value_type}
   end
 
   # Struct and TypedStruct ?
@@ -215,6 +263,8 @@ defmodule ExType.Type do
     defstruct []
   end
 
+  def port, do: %Port{}
+
   defmodule PID do
     @moduledoc false
 
@@ -223,6 +273,8 @@ defmodule ExType.Type do
     defstruct []
   end
 
+  def pid, do: %PID{}
+
   defmodule AnyTuple do
     @moduledoc false
 
@@ -230,6 +282,8 @@ defmodule ExType.Type do
 
     defstruct []
   end
+
+  def any_tuple, do: %AnyTuple{}
 
   defmodule TypedTuple do
     @moduledoc false
@@ -241,6 +295,12 @@ defmodule ExType.Type do
     defstruct [:types]
   end
 
+  def typed_tuple(types) when is_list(types) do
+    Assert.is_list_of_type_structs!(types)
+
+    %TypedTuple{types: types}
+  end
+
   # TODO: distinguish bitstring and binary ???
   defmodule BitString do
     @moduledoc false
@@ -249,4 +309,6 @@ defmodule ExType.Type do
 
     defstruct []
   end
+
+  def bit_string, do: %BitString{}
 end

--- a/lib/example/foo.ex
+++ b/lib/example/foo.ex
@@ -221,4 +221,10 @@ defmodule ExType.Example.Foo do
     %{"hello" => 123}
     |> Map.values()
   end
+
+  @spec add_number(number(), number()) :: number()
+
+  def add_number(x, y) do
+    x + y
+  end
 end

--- a/test/ex_type/argument_expander_test.exs
+++ b/test/ex_type/argument_expander_test.exs
@@ -1,0 +1,40 @@
+defmodule ExType.ArgumentExpanderTest do
+  use ExUnit.Case
+
+  alias ExType.{ArgumentExpander, Type}
+
+  defp assert_equal(left, right) when is_list(left) and is_list(right) do
+    assert Enum.sort(left) == Enum.sort(right)
+  end
+
+  test "expand_union_types/1 with empty args" do
+    assert_equal(ArgumentExpander.expand_union_types([]), [])
+  end
+
+  test "expand_union_types/1 with one arg" do
+    assert_equal(ArgumentExpander.expand_union_types([Type.any()]), [[Type.any()]])
+
+    assert_equal(
+      ArgumentExpander.expand_union_types([
+        Type.union([Type.integer(), Type.float()])
+      ]),
+      [[Type.integer()], [Type.float()]]
+    )
+  end
+
+  test "expand_union_types/1 with multiple args" do
+    assert_equal(
+      ArgumentExpander.expand_union_types([
+        Type.union([Type.integer(), Type.float()]),
+        Type.union([Type.integer(), Type.float()]),
+        Type.any()
+      ]),
+      [
+        [Type.integer(), Type.integer(), Type.any()],
+        [Type.integer(), Type.float(), Type.any()],
+        [Type.float(), Type.float(), Type.any()],
+        [Type.float(), Type.integer(), Type.any()]
+      ]
+    )
+  end
+end


### PR DESCRIPTION
resolved #5 

When eval function with union types, e.g. `Kernel.+(number(), number())`, which is effectively `Kernel.+(float() | integer(), float() | integer())`, it would expand it to 4 evaluations:

1. `Kernel.+(float(), float())`
2. `Kernel.+(float(), integer())`
3. `Kernel.+(integer(), float())`
4. `Kernel.+(integer(), integer())`

And union the result of above evaluations (according to spec [here](https://github.com/elixir-lang/elixir/blob/a861e5b732f195df8eb452aac324eabd6f220f1d/lib/elixir/lib/kernel.ex#L1193-L1196)), which would result `float() | integer()` as final result.