### PR TITLE
Add basic union type support for multi clauses fns

### DIFF
--- a/lib/ex_type/helper.ex
+++ b/lib/ex_type/helper.ex
@@ -27,11 +27,19 @@ defmodule ExType.Helper do
           :error -> "?"
         end
 
+      {:current_stacktrace, [{Process, :info, 2, _} | stacktrace]} =
+        Process.info(self(), :current_stacktrace)
+
       throw(%{
         message: Keyword.get(options, :message, "unknown message"),
         location: "#{file}:#{line}",
         debug_location: "#{__ENV__.file}:#{__ENV__.line}",
-        unmatch: Keyword.get(options, :unmatch, false)
+        unmatch: Keyword.get(options, :unmatch, false),
+        stacktrace:
+          stacktrace
+          |> Enum.map(fn {_module, _fn, _arity, meta} ->
+            "#{Keyword.fetch!(meta, :file)}:#{Keyword.fetch!(meta, :line)}"
+          end)
       })
     end
   end

--- a/lib/ex_type/type.ex
+++ b/lib/ex_type/type.ex
@@ -179,10 +179,11 @@ defmodule ExType.Type do
     @type t :: %__MODULE__{
             arity: integer(),
             clauses: [{[any()], any(), any()}],
-            context: ExType.Context.t()
+            context: ExType.Context.t(),
+            meta: Keyword.t()
           }
 
-    defstruct [:arity, :clauses, :context]
+    defstruct [:arity, :clauses, :context, :meta]
   end
 
   defmodule TypedFunction do

--- a/lib/ex_type/unification.ex
+++ b/lib/ex_type/unification.ex
@@ -80,6 +80,10 @@ defmodule ExType.Unification do
     context
   end
 
+  def unify_pattern(context, atom, %Type.Atom{literal: false}) when is_atom(atom) do
+    context
+  end
+
   def unify_pattern(context, atom, %Type.Any{}) when is_atom(atom) do
     context
   end
@@ -300,7 +304,7 @@ defmodule ExType.Unification do
     Context.update_scope(context, var, %Type.Float{})
   end
 
-  def unify_guard(context, {{:., _, [:erlang, op]}, _, [_, _]}) when op in [:>, :<, :>=, :"=<"] do
+  def unify_guard(context, {{:., _, [:erlang, op]}, _, [_, _]}) when op in [:>, :<, :>=, :"=<", :"=:="] do
     context
   end
 

--- a/lib/ex_type/unification.ex
+++ b/lib/ex_type/unification.ex
@@ -222,19 +222,23 @@ defmodule ExType.Unification do
     end)
   end
 
-  # TODO: check if struct module match
-  def unify_pattern(context, {:%, _, [_struct, {:%{}, _, args}]}, %ExType.Type.Struct{
-        types: types
-      })
-      when is_list(args) do
+  def unify_pattern(
+        context,
+        {:%, _, [struct, {:%{}, _, args}]},
+        %ExType.Type.Struct{
+          struct: struct,
+          types: types
+        }
+      )
+      when is_atom(struct) and is_list(args) do
     Enum.reduce(args, context, fn {key, value}, context when is_atom(key) ->
       unify_pattern(context, value, Map.fetch!(types, key))
     end)
   end
 
-  def unify_pattern(context, pattern, _type) do
+  def unify_pattern(context, pattern, type) do
     Helper.throw(
-      message: "unsupported pattern: #{Macro.to_string(pattern)}",
+      message: "unsupported pattern: #{Macro.to_string(pattern)} #{inspect(type)}",
       context: context,
       meta:
         case pattern do

--- a/lib/example/foo.ex
+++ b/lib/example/foo.ex
@@ -194,6 +194,10 @@ defmodule ExType.Example.Foo do
     x
   end
 
+  def union_example(:error) do
+    "error"
+  end
+
   @spec binary_example(binary()) :: {integer(), integer(), bitstring()}
 
   def binary_example(<<a::1, b::1, c::bits>>) do


### PR DESCRIPTION
This PR added basic union type support for pattern match in multi clauses functions, which should resolved some use case like #9.

use case:
```elixir
@spec example({:a, t1} | {:b, t2} | {:c, t3}) :: any

def example({:a, x}) do
  # ex type should be able to know that `x` is t1 type
end

def example({:b, x}) do
  # ex type should be able to know that `x` is t2 type
end

def example({:c, x}) do
  # ex type should be able to know that `x` is t3 type
end
```